### PR TITLE
Python 2.5 compatibility.

### DIFF
--- a/setuptest/setuptest.py
+++ b/setuptest/setuptest.py
@@ -88,7 +88,7 @@ class SetupTestSuite(unittest.TestSuite):
                     if self.options['label']:
                         try:
                             tests.append(build_test(package))
-                        except (ImproperlyConfigured, ValueError) as e:
+                        except (ImproperlyConfigured, ValueError), e:
                             self.handle_label_exception(e)
                     else:
                         app = get_app(package)
@@ -101,7 +101,7 @@ class SetupTestSuite(unittest.TestSuite):
                             if self.options['label']:
                                 try:
                                     tests.append(build_test(package))
-                                except (ImproperlyConfigured, ValueError) as e:
+                                except (ImproperlyConfigured, ValueError), e:
                                     self.handle_label_exception(e)
                             else:
                                 app = get_app(package)


### PR DESCRIPTION
Django 1.3 still supports Python 2.5

I think thats why django-setuptools should to. And it's as easy as this simple change to the syntax.
