### PR TITLE
python <2.7 does not have argparse in stdlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'coverage',
         'django',
         'pep8',
+        'argparse',
     ],
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
but it is imported in `setuptest/setuptest.py`
