### PR TITLE
Remove unnecessary dependence on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'coverage',
         'django',
         'pep8',
-        'six',
     ],
     classifiers=[
         "Programming Language :: Python",

--- a/setuptest/setuptest.py
+++ b/setuptest/setuptest.py
@@ -7,7 +7,7 @@ import unittest
 
 from coverage import coverage, misc
 from distutils import log
-from six import StringIO
+from django.utils.six import StringIO
 
 
 class LabelException(Exception):


### PR DESCRIPTION
six comes bundled with Django, which setuptest clearly
depends on, so there's no point installing a separate
package.