### PR TITLE
Support for testing against Django 1.7 (trunk)

### DIFF
--- a/setuptest/setuptest.py
+++ b/setuptest/setuptest.py
@@ -21,9 +21,9 @@ class SetupTestSuite(unittest.TestSuite):
     Also runs PEP8 and Coverage checks.
     """
     def __init__(self, *args, **kwargs):
-        self.configure()
         self.cov = coverage()
         self.cov.start()
+        self.configure()
         self.packages = self.resolve_packages()
 
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
as of the great App Refactor done in december, there are changes to the way Django and packages are instantiated & setup, specifically:
- Django now has a `setup` method which is (IIRC) where startup related code goes
- apps previously got via `get_app` should instead be requesting the `AppConfig` instance for that package, which carries with it data about where the models module is, etc.

This changeset tries to call `setup` if possible, and switches out the old `get_app` method if it detects it can load the app config instead.

Without these two changes, running tests against `master` results in the follow issues:
- without calling `django.setup`, an exception is raised to say the App Registry is not ready yet.
- without requesting the app config instead of the app, `build_suite` fails as it now tries to access the `models_module` attribute of the provided object (the `app` variable, in setuptest).

The version of master needs to be recent, so that [ticket 21833](https://code.djangoproject.com/ticket/21833) is fixed.
