### PR TITLE
Only run attempt to run south on django<1.7

### DIFF
--- a/setuptest/setuptest.py
+++ b/setuptest/setuptest.py
@@ -1,4 +1,5 @@
 import argparse
+import django
 import pep8
 import sys
 import time
@@ -47,11 +48,12 @@ class SetupTestSuite(unittest.TestSuite):
         )
         # South patches the test management command to handle the
         # SOUTH_TESTS_MIGRATE setting. Apply that patch if South is installed.
-        try:
-            from south.management.commands import patch_for_test_db_setup
-            patch_for_test_db_setup()
-        except ImportError:
-            pass
+        if django.VERSION < (1,7):
+            try:
+                from south.management.commands import patch_for_test_db_setup
+                patch_for_test_db_setup()
+            except ImportError:
+                pass
         self.test_runner.setup_test_environment()
         self.old_config = self.test_runner.setup_databases()
 


### PR DESCRIPTION
The try except isn't enough. Just having South installed on the same system will make it fail with AttributeError: 'module' object has no attribute '_commands'.
