### PR TITLE
Django 1.9 support

### DIFF
--- a/setuptest/setuptest.py
+++ b/setuptest/setuptest.py
@@ -147,7 +147,11 @@ class SetupTestSuite(unittest.TestSuite):
 
         import django
         from django.conf import settings
-        from django.utils.importlib import import_module
+        try:
+            from importlib import import_module
+        except ImportError:
+            # Django < 1.9
+            from django.utils.importlib import import_module
         try:
             test_settings = import_module('test_settings')
         except ImportError as e:


### PR DESCRIPTION
Works with (at least) 1.9b1. django.utils.importlib was deprecated in 1.7:

  https://docs.djangoproject.com/en/1.8/releases/1.7/#deprecated-features-1-7
